### PR TITLE
Fix miliseconds and Zulu parse

### DIFF
--- a/src/bucdate.erl
+++ b/src/bucdate.erl
@@ -281,12 +281,12 @@ parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $-, Off | _Rest ], _Now, 
 parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms, $-, Off | _Rest ], _Now, _Opts)
   when  (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X))
         andalso Year > 31 ->
-    {{Year, Month, Day}, {hour(Hour, []) - Off, Min, Sec}, {Ms}};
+    {{Year, Month, Day}, {hour(Hour, []) + Off, Min, Sec}, {Ms}};
 
 parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms, $+, Off | _Rest ], _Now, _Opts)
   when  (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X))
         andalso Year > 31 ->
-    {{Year, Month, Day}, {hour(Hour, []) + Off, Min, Sec}, {Ms}};
+    {{Year, Month, Day}, {hour(Hour, []) - Off, Min, Sec}, {Ms}};
 
 %% Date/Times 22 Aug 2008 6:35.0001 PM
 parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms | PAM], _Now, _Opts)

--- a/src/bucdate.erl
+++ b/src/bucdate.erl
@@ -284,6 +284,9 @@ parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms | PAM], _Now, _Opt
        (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X))
        andalso ?IS_YEAR(Year) ->
     {{Year, Month, Day}, {hour(Hour, PAM), Min, Sec}, {Ms}};
+parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms , $Z], _Now, _Opts)
+  when (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X)) andalso ?IS_YEAR(Year) ->
+    {{Year, Month, Day}, {hour(Hour, []), Min, Sec}, {Ms}};
 parse([Month, X, Day, X, Year, Hour, $:, Min, $:, Sec, $., Ms | PAM], _Now, _Opts)
   when ?IS_MERIDIAN(PAM) andalso ?IS_US_SEP(X)
        andalso ?IS_YEAR(Year) ->

--- a/src/bucdate.erl
+++ b/src/bucdate.erl
@@ -278,6 +278,16 @@ parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $-, Off | _Rest ], _Now, 
         andalso Year > 31 ->
     {{Year, Month, Day}, {hour(Hour, []) + Off, Min, Sec}, {0}};
 
+parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms, $-, Off | _Rest ], _Now, _Opts)
+  when  (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X))
+        andalso Year > 31 ->
+    {{Year, Month, Day}, {hour(Hour, []) - Off, Min, Sec}, {Ms}};
+
+parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms, $+, Off | _Rest ], _Now, _Opts)
+  when  (?IS_US_SEP(X) orelse ?IS_WORLD_SEP(X))
+        andalso Year > 31 ->
+    {{Year, Month, Day}, {hour(Hour, []) + Off, Min, Sec}, {Ms}};
+
 %% Date/Times 22 Aug 2008 6:35.0001 PM
 parse([Year, X, Month, X, Day, Hour, $:, Min, $:, Sec, $., Ms | PAM], _Now, _Opts)
   when ?IS_MERIDIAN(PAM) andalso

--- a/test/bucdate_tests.erl
+++ b/test/bucdate_tests.erl
@@ -227,7 +227,9 @@ t_parse_with_TZ() ->
   ?assertEqual({{2008, 8, 22}, {17, 16, 17}},
                bucdate:parse("Sat 22nd of August 2008 UTC", ?DATE)),
   ?assertEqual({{2008, 8, 22}, {17, 16, 17}},
-               bucdate:parse("Sat 22nd of August 2008 DST", ?DATE)).
+               bucdate:parse("Sat 22nd of August 2008 DST", ?DATE)),
+  ?assertEqual({{2008, 8, 22}, {17, 16, 17, 0}},
+               bucdate:parse("2008-08-22T17:16:17.00000Z", ?DATE)).
 
 t_iso() ->
   ?assertEqual("2004 W53", bucdate:format(?ISO, {{2005, 1, 1}, {1, 1, 1}})),

--- a/test/bucdate_tests.erl
+++ b/test/bucdate_tests.erl
@@ -229,7 +229,11 @@ t_parse_with_TZ() ->
   ?assertEqual({{2008, 8, 22}, {17, 16, 17}},
                bucdate:parse("Sat 22nd of August 2008 DST", ?DATE)),
   ?assertEqual({{2008, 8, 22}, {17, 16, 17, 0}},
-               bucdate:parse("2008-08-22T17:16:17.00000Z", ?DATE)).
+               bucdate:parse("2008-08-22T17:16:17.00000Z", ?DATE)),
+  ?assertEqual({{2008, 8, 22}, {18, 16, 17, 0}},
+               bucdate:parse("2008-08-22T17:16:17.00000+01:00", ?DATE)),
+  ?assertEqual({{2008, 8, 22}, {16, 16, 17, 0}},
+               bucdate:parse("2008-08-22T17:16:17.00000-01:00", ?DATE)).
 
 t_iso() ->
   ?assertEqual("2004 W53", bucdate:format(?ISO, {{2005, 1, 1}, {1, 1, 1}})),

--- a/test/bucdate_tests.erl
+++ b/test/bucdate_tests.erl
@@ -230,9 +230,9 @@ t_parse_with_TZ() ->
                bucdate:parse("Sat 22nd of August 2008 DST", ?DATE)),
   ?assertEqual({{2008, 8, 22}, {17, 16, 17, 0}},
                bucdate:parse("2008-08-22T17:16:17.00000Z", ?DATE)),
-  ?assertEqual({{2008, 8, 22}, {18, 16, 17, 0}},
-               bucdate:parse("2008-08-22T17:16:17.00000+01:00", ?DATE)),
   ?assertEqual({{2008, 8, 22}, {16, 16, 17, 0}},
+               bucdate:parse("2008-08-22T17:16:17.00000+01:00", ?DATE)),
+  ?assertEqual({{2008, 8, 22}, {18, 16, 17, 0}},
                bucdate:parse("2008-08-22T17:16:17.00000-01:00", ?DATE)).
 
 t_iso() ->


### PR DESCRIPTION
fixes parsing when miliseconds are present. for datetime like : `1997-07-16T19:20:30.45+01:00` or `1997-07-16T19:20:30.45Z`

ref: https://www.w3.org/TR/NOTE-datetime