### PR TITLE
Declare dependancy on eunit in mix file for elixir 1.15 compatibility

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Bucs.Mixfile do
   def application do
     [
        applications: [:inets],
+       extra_applications: [eunit: :optional],
        env: [],
        mod: {:bucs_app, []}
     ]


### PR DESCRIPTION
Without this config, compiling on elixir 1.15 errors with
```
src/bucs.erl:3:14: can't find include lib "eunit/include/eunit.hrl"
%    3| -include_lib("eunit/include/eunit.hrl").
%     |              ^
```